### PR TITLE
Put mysociety-docs-theme config into Sass scope

### DIFF
--- a/_sass/global.scss
+++ b/_sass/global.scss
@@ -1,1 +1,2 @@
+@import "../assets/sass/config";
 @import "../theme/sass/global.scss";

--- a/assets/sass/_config.scss
+++ b/assets/sass/_config.scss
@@ -1,4 +1,4 @@
-// This config is @imported by /theme/sass/global.scss
+// This config is @imported before /theme/sass/global.scss
 
 $logo_path: "../img/logo_dev.svg";
 $logo_width: 501px;


### PR DESCRIPTION
Update for compatibility with mysociety-docs-theme which now expects config variables to be in scope when global.scss is compiled (mysociety/mysociety-docs-theme#23).