### PR TITLE
[#37] Fix outdated footer links, add `Climate` project

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,9 +13,10 @@
                 <nav class="mysoc-footer__links">
                     <ul>
                         <li role="presentation"><a href="https://www.mysociety.org?utm_source=mysociety.github.io&amp;utm_content=footer+mysociety+tools&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">mySociety tools</a></li>
-                        <li role="presentation"><a href="https://www.mysociety.org/freedom-of-information/?utm_source=mysociety.github.io&amp;utm_content=footer+freedom+of+information&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">Freedom of Information</a></li>
-                        <li role="presentation"><a href="https://www.mysociety.org/better-cities/?utm_source=mysociety.github.io&amp;utm_content=footer+better+cities&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">Better cities</a></li>
+                        <li role="presentation"><a href="https://www.mysociety.org/transparency/?utm_source=mysociety.github.io&amp;utm_content=footer+transparency&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">Transparency</a></li>
+                        <li role="presentation"><a href="https://www.mysociety.org/community/?utm_source=mysociety.github.io&amp;utm_content=footer+community&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">Community</a></li>
                         <li role="presentation"><a href="https://www.mysociety.org/democracy/?utm_source=mysociety.github.io&amp;utm_content=footer+democracy&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">Democracy</a></li>
+                        <li role="presentation"><a href="https://www.mysociety.org/climate/?utm_source=mysociety.github.io&amp;utm_content=footer+climate&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">Climate</a></li>
                     </ul>
                     <ul>
                         <li role="presentation"><a href="https://groups.google.com/a/mysociety.org/forum/#!forum/mysociety-community">Mailing list</a></li>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,8 +19,9 @@
                     </ul>
                     <ul>
                         <li role="presentation"><a href="https://groups.google.com/a/mysociety.org/forum/#!forum/mysociety-community">Mailing list</a></li>
+                        <li role="presentation"><a href="https://www.mysociety.org/our-research/?utm_source=mysociety.github.io&amp;utm_content=footer+research&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">Research</a></li>
+                        <li role="presentation"><a href="https://data.mysociety.org/?utm_source=mysociety.github.io&amp;utm_content=footer+data&amp;utm_medium=link&amp;utm_campaign=mysoc_footer">Data and APIs</a></li>
                         <li role="presentation"><a href="https://github.com/mysociety">GitHub</a></li>
-                        <li role="presentation"><a href="http://www.irc.mysociety.org/">IRC</a></li>
                     </ul>
                 </nav>
             </div>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #37

## What does this do?
This renames the outdated 'Freedom of Information' and 'Better Cities' projects to _**'Transparency'**_ and **_'Community'_** respectively, and adds **_'Climate'_**.

It also removes the outdated 'IRC' server link, and adds **_'Research'_** and **_'Data and APIs'_** in their place.

## Why was this needed?

The link to IRC made me sad - and clearly including  the _**climate**_ project is quite important! 🌍 

## Implementation notes

Hopefully nothing too controversial - the one concern is that the right hand column is slightly disjointed, but it already was, so this is just a continuation. If an extra link is needed, what about _'Careers'_?

## Screenshots
### Before:
<img src="https://user-images.githubusercontent.com/249418/180707501-7e02f05a-a74e-4c9b-8e99-5da3d65f5a81.png" width="500px" alt="Image of the standard mySociety footer, showing projects 'Freedom of Information', 'Better Cities', and 'Democracy'; followed by 'Mailing List', 'IRC', and 'GitHub'">
### After:
<img src="https://user-images.githubusercontent.com/249418/180707703-70b47c21-0fc9-40dc-9c0e-0b887040cf94.png" width="500px" alt="Image of the standard mySociety footer, showing projects 'Transparency', 'Community', 'Democracy', and 'Climate'; followed by 'Mailing List', 'Research', 'Data and APIs', and 'GitHub'">

## Notes to reviewer
Forgive the intrusion please! 🙏 